### PR TITLE
Fix error when trying to read GITHUB_VCS_PACKAGES_ACCESS_TOKEN

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ http_get() {
 
 echo "-----> Setting up git SSH to HTTPS override"
 
-read -r GITHUB_PAT < "$ENV_DIR/GITHUB_VCS_PACKAGES_ACCESS_TOKEN"
+GITHUB_PAT=$(cat "$ENV_DIR/GITHUB_VCS_PACKAGES_ACCESS_TOKEN")
 
 
 # Git URL as suggested by the GitHub UI for copy pasting.


### PR DESCRIPTION
The file containing the token does not end in a `\n` character, and read exits with a non-0 status code, even if it does read and set the variable.